### PR TITLE
Update main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -44,6 +44,19 @@ class Divera247 extends utils.Adapter {
 						},
 						native: {},
 					});
+					
+					// Creating the Object 'foreign_ID' -> response JSON key 'data.foreign_ID'
+					this.setObjectNotExistsAsync('foreign_ID', {
+						type: 'state',
+						common: {
+							name: 'Einsatznummer',
+							type: 'number',
+							role: 'text',
+							read: true,
+							write: false
+						},
+						native: {},
+					});
 
 					// Creating the Object 'title' -> response JSON key 'data.title'
 					this.setObjectNotExistsAsync('title', {
@@ -162,8 +175,9 @@ class Divera247 extends utils.Adapter {
 						native: {},
 					});
 
-					// Initialisation of the states
+					// Initialisation of the states 
 					this.setState('alarm', { val: false, ack: true });
+					this.setState('foreign_ID', { val: null, ack: true });
 					this.setState('title', { val: null, ack: true });
 					this.setState('text', { val: null, ack: true });
 					this.setState('address', { val: null, ack: true });
@@ -254,6 +268,7 @@ class Divera247 extends utils.Adapter {
 					lastAlarmId = content.data.id;
 					lastAlarmStatus = content.success;
 					this.setState('alarm', { val: content.success, ack: true });
+					this.setState('foreign_ID', { val: content.data.foreign_ID, ack: true });
 					this.setState('title', { val: content.data.title, ack: true });
 					this.setState('text', { val: content.data.text, ack: true });
 					this.setState('address', { val: content.data.address, ack: true });

--- a/main.js
+++ b/main.js
@@ -136,6 +136,19 @@ class Divera247 extends utils.Adapter {
 						native: {},
 					});
 
+					// Creating the Object 'group' -> response JSON key 'data.group'
+					this.setObjectNotExistsAsync('group', {
+						type: 'state',
+						common: {
+							name: 'Gruppe',
+							type: 'string',
+							role: 'text',
+							read: true,
+							write: false
+						},
+						native: {},
+					});
+
 					// Creating the Object 'lastUpdate' -> current timestamp
 					this.setObjectNotExistsAsync('lastUpdate', {
 						type: 'state',
@@ -158,6 +171,7 @@ class Divera247 extends utils.Adapter {
 					this.setState('lng', { val: null, ack: true });
 					this.setState('date', { val: null, ack: true });
 					this.setState('priority', { val: null, ack: true });
+					this.setState('group', { val: null, ack: true });
 					this.setState('lastUpdate', { val: null, ack: true });
 
 					// Registration of an interval calling the main function for this adapter
@@ -247,6 +261,7 @@ class Divera247 extends utils.Adapter {
 					this.setState('lng', { val: content.data.lng, ack: true });
 					this.setState('date', { val: content.data.date * 1000, ack: true });
 					this.setState('priority', { val: content.data.priority, ack: true });
+					this.setState('group', { val: content.data.group, ack: true });
 				} else if (content.success != lastAlarmStatus) {
 					lastAlarmStatus = content.success;
 					this.setState('alarm', { val: content.success, ack: true });


### PR DESCRIPTION
add group

In unserer DIVERA 24/7 Version werden in Hauptsache Gruppen alarmiert. 
Um dies zu selektieren, wurde der Datenpunkte Gruppe eingefügt.
Es wird jedoch kein Volltext der Gruppe wiedergegeben jedoch eine eindeutige Zahlenfolge. 
Diese Nr. kann nicht direkt aus der Divera Oberfläche entnommen werden. 